### PR TITLE
Fix: Run command in github actions workflow

### DIFF
--- a/.github/workflows/csv-bucket-upload.yml
+++ b/.github/workflows/csv-bucket-upload.yml
@@ -25,6 +25,6 @@ jobs:
 
       - name: Upload Only New CSVs to GCS
         run: |
-          gsutil -n cp data/*.csv gs://cso-exercise-ingestion-raw/
+          gsutil rsync -r -n cp data/*.csv gs://cso-exercise-ingestion-raw/
 
           


### PR DESCRIPTION
Fixed run command in github actions workflow by replacing invalid syntax. The syntax was supposed to stop the overwriting of files in GCS and only add new files or files that had been changed. 

The merge will test whether the update has worked correctly